### PR TITLE
Fix dependabot branch not existing.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,10 @@ updates:
   # Maintain dependencies for Gradle dependencies
   - package-ecosystem: "gradle"
     directory: "/"
-    target-branch: "next"
     schedule:
       interval: "daily"
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "next"
     schedule:
       interval: "daily"


### PR DESCRIPTION
The "next" branch does not exist in our repo, so dependabot was not doing anything. Setting back to the default branch.