### PR TITLE
Replace try/catch with assertFailsWith in tests

### DIFF
--- a/src/test/kotlin/ch/kleis/lcaplugin/core/allocation/AllocationTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/core/allocation/AllocationTest.kt
@@ -12,6 +12,7 @@ import ch.kleis.lcaplugin.core.lang.value.SystemValue
 import ch.kleis.lcaplugin.core.lang.value.TechnoExchangeValue
 import org.junit.Assert
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class AllocationTest {
     @Test
@@ -236,12 +237,10 @@ class AllocationTest {
             listOf(),
             listOf()
         )
-        // when + then
-        try {
-            allocation.allocationUnitCheck(processValue)
-        } catch (e: AssertionError) {
-            Assert.fail("Should not fail")
-        }
+        // when
+        allocation.allocationUnitCheck(processValue)
+
+        // then should not throw.
     }
 
     @Test
@@ -314,16 +313,11 @@ class AllocationTest {
             listOf(),
             listOf()
         )
-        // when
-        try {
-            Allocation().allocationUnitCheck(processValue)
-            Assert.fail("Should throw an error")
-        } catch (e: EvaluatorException) {
-            Assert.assertEquals(
-                "Only percent is allowed for allocation unit (process: ${processValue.name})",
-                e.message
-            )
-        }
+        // when + then
+        assertFailsWith(
+            EvaluatorException::class,
+            "Only percent is allowed for allocation unit (process: ${processValue.name})"
+        ) { Allocation().allocationUnitCheck(processValue) }
     }
 
     @Test
@@ -341,12 +335,8 @@ class AllocationTest {
             listOf(),
             listOf()
         )
-        // when
-        try {
-            Allocation().allocationUnitCheck(processValue)
-        } catch (e: EvaluatorException) {
-            Assert.fail("Should throw an error")
-        }
+        // when, then should not throw
+        Allocation().allocationUnitCheck(processValue)
     }
 
     @Test
@@ -364,16 +354,11 @@ class AllocationTest {
             listOf(),
             listOf()
         )
-        // when
-        try {
-            Allocation().allocationUnitCheck(processValue)
-            Assert.fail("Should throw an error")
-        } catch (e: EvaluatorException) {
-            Assert.assertEquals(
-                "The sum of the allocations should be hundred percent (process: ${processValue.name})",
-                e.message
-            )
-        }
+        // when + then
+        assertFailsWith(
+            EvaluatorException::class,
+            "The sum of the allocations should be hundred percent (process: ${processValue.name})"
+        ) { Allocation().allocationUnitCheck(processValue) }
     }
 
     @Test
@@ -396,12 +381,8 @@ class AllocationTest {
             listOf(),
             listOf()
         )
-        // when
-        try {
-            Allocation().allocationUnitCheck(processValue)
-        } catch (e: EvaluatorException) {
-            Assert.fail("Should throw an error")
-        }
+        // when V then should not throw.
+        Allocation().allocationUnitCheck(processValue)
     }
 
     @Test
@@ -424,15 +405,10 @@ class AllocationTest {
             listOf(),
             listOf()
         )
-        // when
-        try {
-            Allocation().allocationUnitCheck(processValue)
-            Assert.fail("Should throw an error")
-        } catch (e: EvaluatorException) {
-            Assert.assertEquals(
-                "Only percent is allowed for allocation unit (process: ${processValue.name})",
-                e.message
-            )
-        }
+        // when + then
+        assertFailsWith(
+            EvaluatorException::class,
+            "Only percent is allowed for allocation unit (process: ${processValue.name})"
+        ) { Allocation().allocationUnitCheck(processValue) }
     }
 }

--- a/src/test/kotlin/ch/kleis/lcaplugin/core/lang/evaluator/EvaluatorTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/core/lang/evaluator/EvaluatorTest.kt
@@ -8,8 +8,10 @@ import ch.kleis.lcaplugin.core.lang.value.FromProcessRefValue
 import ch.kleis.lcaplugin.core.lang.value.ProcessValue
 import ch.kleis.lcaplugin.core.lang.value.TechnoExchangeValue
 import com.intellij.openapi.ui.naturalSorted
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class EvaluatorTest {
     @Test
@@ -35,34 +37,34 @@ class EvaluatorTest {
     fun eval_withImplicitProcessResolution_thenCorrectSystem() {
         // given
         val processTemplates: Register<EProcessTemplate> = Register.from(
-            mapOf(
-                "carrot_production" to TemplateFixture.carrotProduction
-            )
+                mapOf(
+                        "carrot_production" to TemplateFixture.carrotProduction
+                )
         )
         val symbolTable = SymbolTable(
-            processTemplates = processTemplates,
+                processTemplates = processTemplates,
         )
         val expression = EProcessTemplate(
-            emptyMap(),
-            emptyMap(),
-            EProcess(
-                name = "salad_production",
-                products = listOf(
-                    ETechnoExchange(
-                        QuantityFixture.oneKilogram,
-                        ProductFixture.salad,
-                    )
-                ),
-                inputs = listOf(
-                    ETechnoExchange(
-                        QuantityFixture.oneKilogram,
-                        EProductSpec(
-                            "carrot",
-                        )
-                    )
-                ),
-                biosphere = emptyList()
-            )
+                emptyMap(),
+                emptyMap(),
+                EProcess(
+                        name = "salad_production",
+                        products = listOf(
+                                ETechnoExchange(
+                                        QuantityFixture.oneKilogram,
+                                        ProductFixture.salad,
+                                )
+                        ),
+                        inputs = listOf(
+                                ETechnoExchange(
+                                        QuantityFixture.oneKilogram,
+                                        EProductSpec(
+                                                "carrot",
+                                        )
+                                )
+                        ),
+                        biosphere = emptyList()
+                )
         )
         val recursiveEvaluator = Evaluator(symbolTable)
 
@@ -71,57 +73,57 @@ class EvaluatorTest {
 
         // then
         val expected = setOf(
-            ProcessValue(
-                name = "carrot_production",
-                products = listOf(
-                    TechnoExchangeValue(
-                        QuantityValueFixture.oneKilogram,
-                        ProductValueFixture.carrot.withFromProcessRef(
-                            FromProcessRefValue(
-                                "carrot_production",
-                                mapOf(
-                                    "q_water" to QuantityValueFixture.oneLitre
-                                ),
-                            )
-                        )
-                    )
+                ProcessValue(
+                        name = "carrot_production",
+                        products = listOf(
+                                TechnoExchangeValue(
+                                        QuantityValueFixture.oneKilogram,
+                                        ProductValueFixture.carrot.withFromProcessRef(
+                                                FromProcessRefValue(
+                                                        "carrot_production",
+                                                        mapOf(
+                                                                "q_water" to QuantityValueFixture.oneLitre
+                                                        ),
+                                                )
+                                        )
+                                )
+                        ),
+                        inputs = listOf(
+                                TechnoExchangeValue(
+                                        QuantityValueFixture.oneLitre,
+                                        ProductValueFixture.water
+                                )
+                        ),
+                        biosphere = emptyList(),
                 ),
-                inputs = listOf(
-                    TechnoExchangeValue(
-                        QuantityValueFixture.oneLitre,
-                        ProductValueFixture.water
-                    )
+                ProcessValue(
+                        name = "salad_production",
+                        products = listOf(
+                                TechnoExchangeValue(
+                                        QuantityValueFixture.oneKilogram,
+                                        ProductValueFixture.salad.withFromProcessRef(
+                                                FromProcessRefValue(
+                                                        "salad_production",
+                                                        emptyMap(),
+                                                )
+                                        )
+                                )
+                        ),
+                        inputs = listOf(
+                                TechnoExchangeValue(
+                                        QuantityValueFixture.oneKilogram,
+                                        ProductValueFixture.carrot.withFromProcessRef(
+                                                FromProcessRefValue(
+                                                        "carrot_production",
+                                                        mapOf(
+                                                                "q_water" to QuantityValueFixture.oneLitre,
+                                                        ),
+                                                )
+                                        )
+                                )
+                        ),
+                        biosphere = emptyList(),
                 ),
-                biosphere = emptyList(),
-            ),
-            ProcessValue(
-                name = "salad_production",
-                products = listOf(
-                    TechnoExchangeValue(
-                        QuantityValueFixture.oneKilogram,
-                        ProductValueFixture.salad.withFromProcessRef(
-                            FromProcessRefValue(
-                                "salad_production",
-                                emptyMap(),
-                            )
-                        )
-                    )
-                ),
-                inputs = listOf(
-                    TechnoExchangeValue(
-                        QuantityValueFixture.oneKilogram,
-                        ProductValueFixture.carrot.withFromProcessRef(
-                            FromProcessRefValue(
-                                "carrot_production",
-                                mapOf(
-                                    "q_water" to QuantityValueFixture.oneLitre,
-                                ),
-                            )
-                        )
-                    )
-                ),
-                biosphere = emptyList(),
-            ),
         ).naturalSorted()
         assertEquals(expected, actual)
     }
@@ -130,39 +132,39 @@ class EvaluatorTest {
     fun eval_whenExistsFromProcessRef_thenCorrectSystem() {
         // given
         val processTemplates: Register<EProcessTemplate> = Register.from(
-            mapOf(
-                "carrot_production" to TemplateFixture.carrotProduction
-            )
+                mapOf(
+                        "carrot_production" to TemplateFixture.carrotProduction
+                )
         )
         val symbolTable = SymbolTable(
-            processTemplates = processTemplates,
+                processTemplates = processTemplates,
         )
         val expression = EProcessTemplate(
-            emptyMap(),
-            emptyMap(),
-            EProcess(
-                name = "salad_production",
-                products = listOf(
-                    ETechnoExchange(
-                        QuantityFixture.oneKilogram,
-                        ProductFixture.salad,
-                    )
-                ),
-                inputs = listOf(
-                    ETechnoExchange(
-                        QuantityFixture.oneKilogram,
-                        EProductSpec(
-                            "carrot",
-                            UnitFixture.kg,
-                            FromProcessRef(
-                                "carrot_production",
-                                mapOf("q_water" to QuantityFixture.twoLitres),
-                            ),
-                        )
-                    )
-                ),
-                biosphere = emptyList()
-            )
+                emptyMap(),
+                emptyMap(),
+                EProcess(
+                        name = "salad_production",
+                        products = listOf(
+                                ETechnoExchange(
+                                        QuantityFixture.oneKilogram,
+                                        ProductFixture.salad,
+                                )
+                        ),
+                        inputs = listOf(
+                                ETechnoExchange(
+                                        QuantityFixture.oneKilogram,
+                                        EProductSpec(
+                                                "carrot",
+                                                UnitFixture.kg,
+                                                FromProcessRef(
+                                                        "carrot_production",
+                                                        mapOf("q_water" to QuantityFixture.twoLitres),
+                                                ),
+                                        )
+                                )
+                        ),
+                        biosphere = emptyList()
+                )
         )
         val recursiveEvaluator = Evaluator(symbolTable)
 
@@ -171,56 +173,56 @@ class EvaluatorTest {
 
         // then
         val expected = setOf(
-            ProcessValue(
-                name = "salad_production",
-                products = listOf(
-                    TechnoExchangeValue(
-                        QuantityValueFixture.oneKilogram,
-                        ProductValueFixture.salad.withFromProcessRef(
-                            FromProcessRefValue(
-                                "salad_production",
-                                emptyMap(),
-                            )
-                        )
-                    )
-                ),
-                inputs = listOf(
-                    TechnoExchangeValue(
-                        QuantityValueFixture.oneKilogram,
-                        ProductValueFixture.carrot.withFromProcessRef(
-                            FromProcessRefValue(
-                                "carrot_production", mapOf(
-                                    "q_water" to QuantityValueFixture.twoLitres
+                ProcessValue(
+                        name = "salad_production",
+                        products = listOf(
+                                TechnoExchangeValue(
+                                        QuantityValueFixture.oneKilogram,
+                                        ProductValueFixture.salad.withFromProcessRef(
+                                                FromProcessRefValue(
+                                                        "salad_production",
+                                                        emptyMap(),
+                                                )
+                                        )
                                 )
-                            )
-                        )
-                    )
+                        ),
+                        inputs = listOf(
+                                TechnoExchangeValue(
+                                        QuantityValueFixture.oneKilogram,
+                                        ProductValueFixture.carrot.withFromProcessRef(
+                                                FromProcessRefValue(
+                                                        "carrot_production", mapOf(
+                                                        "q_water" to QuantityValueFixture.twoLitres
+                                                )
+                                                )
+                                        )
+                                )
+                        ),
+                        biosphere = emptyList(),
                 ),
-                biosphere = emptyList(),
-            ),
-            ProcessValue(
-                name = "carrot_production",
-                products = listOf(
-                    TechnoExchangeValue(
-                        QuantityValueFixture.oneKilogram,
-                        ProductValueFixture.carrot.withFromProcessRef(
-                            FromProcessRefValue(
-                                "carrot_production",
-                                mapOf(
-                                    "q_water" to QuantityValueFixture.twoLitres
-                                ),
-                            ),
-                        )
-                    )
+                ProcessValue(
+                        name = "carrot_production",
+                        products = listOf(
+                                TechnoExchangeValue(
+                                        QuantityValueFixture.oneKilogram,
+                                        ProductValueFixture.carrot.withFromProcessRef(
+                                                FromProcessRefValue(
+                                                        "carrot_production",
+                                                        mapOf(
+                                                                "q_water" to QuantityValueFixture.twoLitres
+                                                        ),
+                                                ),
+                                        )
+                                )
+                        ),
+                        inputs = listOf(
+                                TechnoExchangeValue(
+                                        QuantityValueFixture.twoLitres,
+                                        ProductValueFixture.water
+                                )
+                        ),
+                        biosphere = emptyList(),
                 ),
-                inputs = listOf(
-                    TechnoExchangeValue(
-                        QuantityValueFixture.twoLitres,
-                        ProductValueFixture.water
-                    )
-                ),
-                biosphere = emptyList(),
-            ),
         ).naturalSorted()
         assertEquals(expected, actual)
     }
@@ -229,82 +231,80 @@ class EvaluatorTest {
     fun eval_whenProductDoesNotMatchProcess_shouldThrow() {
         // given
         val symbolTable = SymbolTable(
-            processTemplates = Register.from(
-                mapOf(
-                    "carrot_production" to TemplateFixture.carrotProduction
+                processTemplates = Register.from(
+                        mapOf(
+                                "carrot_production" to TemplateFixture.carrotProduction
+                        )
                 )
-            )
         )
         val expression = EProcessTemplate(
-            emptyMap(),
-            emptyMap(),
-            EProcess(
-                name = "carrot_production",
-                products = listOf(
-                    ETechnoExchange(
-                        QuantityFixture.oneKilogram,
-                        ProductFixture.salad,
-                    )
-                ),
-                inputs = listOf(
-                    ETechnoExchange(
-                        QuantityFixture.oneKilogram,
-                        EProductSpec(
-                            "irrelevant_product",
-                            UnitFixture.kg,
-                            FromProcessRef(
-                                "carrot_production",
-                                mapOf("q_water" to QuantityFixture.twoLitres),
-                            ),
-                        )
-                    )
-                ),
-                biosphere = emptyList()
-            )
+                emptyMap(),
+                emptyMap(),
+                EProcess(
+                        name = "carrot_production",
+                        products = listOf(
+                                ETechnoExchange(
+                                        QuantityFixture.oneKilogram,
+                                        ProductFixture.salad,
+                                )
+                        ),
+                        inputs = listOf(
+                                ETechnoExchange(
+                                        QuantityFixture.oneKilogram,
+                                        EProductSpec(
+                                                "irrelevant_product",
+                                                UnitFixture.kg,
+                                                FromProcessRef(
+                                                        "carrot_production",
+                                                        mapOf("q_water" to QuantityFixture.twoLitres),
+                                                ),
+                                        )
+                                )
+                        ),
+                        biosphere = emptyList()
+                )
         )
         val recursiveEvaluator = Evaluator(symbolTable)
 
         // when/then
-        try {
-            recursiveEvaluator.eval(expression)
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            assertEquals("no process 'carrot_production' providing 'irrelevant_product' found", e.message)
-        }
+        assertFailsWith(
+                EvaluatorException::class,
+                "no process 'carrot_production' providing 'irrelevant_product' found"
+        ) { recursiveEvaluator.eval(expression) }
     }
 
     @Test
     fun eval_whenNonEmptyBiosphere_thenIncludeSubstanceCharacterization() {
         // given
         val symbolTable = SymbolTable(
-            substanceCharacterizations = Register.from(
-                mapOf(
-                    "propanol" to SubstanceCharacterizationFixture.propanolCharacterization,
-                )
-            ),
+                substanceCharacterizations = Register.from(
+                        mapOf(
+                                "propanol" to SubstanceCharacterizationFixture.propanolCharacterization,
+                        )
+                ),
         )
         val expression = EProcessTemplate(
-            emptyMap(),
-            emptyMap(),
-            EProcess(
-                name = "carrot_production",
-                products = listOf(
-                    ETechnoExchange(
-                        QuantityFixture.oneKilogram,
-                        ProductFixture.salad,
-                    )
-                ),
-                inputs = emptyList(),
-                biosphere = listOf(
-                    EBioExchange(
-                        QuantityFixture.oneKilogram, ESubstanceSpec(
-                            "propanol",
-                            compartment = "air",
-                            type = SubstanceType.RESOURCE,
+                emptyMap(),
+                emptyMap(),
+                EProcess(
+                        name = "carrot_production",
+                        products = listOf(
+                                ETechnoExchange(
+                                        QuantityFixture.oneKilogram,
+                                        ProductFixture.salad,
+                                )
+                        ),
+                        inputs = emptyList(),
+                        biosphere = listOf(
+                                EBioExchange(
+                                        QuantityFixture.oneKilogram, ESubstanceSpec(
+                                        "propanol",
+                                        compartment = "air",
+                                        type = SubstanceType.RESOURCE,
+                                )
+                                )
                         )
-                    )
                 )
-            )
         )
         val recursiveEvaluator = Evaluator(symbolTable)
 
@@ -313,7 +313,7 @@ class EvaluatorTest {
 
         // then
         val expected = setOf(
-            SubstanceCharacterizationValueFixture.propanolCharacterization
+                SubstanceCharacterizationValueFixture.propanolCharacterization
         )
         assertEquals(expected, actual)
     }

--- a/src/test/kotlin/ch/kleis/lcaplugin/core/lang/evaluator/reducer/ProcessTemplateExpressionReducerTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/core/lang/evaluator/reducer/ProcessTemplateExpressionReducerTest.kt
@@ -5,8 +5,8 @@ import ch.kleis.lcaplugin.core.lang.evaluator.EvaluatorException
 import ch.kleis.lcaplugin.core.lang.expression.*
 import ch.kleis.lcaplugin.core.lang.fixture.*
 import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class ProcessTemplateExpressionReducerTest {
 
@@ -111,12 +111,7 @@ class ProcessTemplateExpressionReducerTest {
         val reducer = TemplateExpressionReducer()
 
         // when/then
-        try {
-            reducer.reduce(expression)
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            assertEquals("unknown parameters: [foo]", e.message)
-        }
+        assertFailsWith(EvaluatorException::class, "unknown parameters: [foo]") { reducer.reduce(expression) }
     }
 
     @Test

--- a/src/test/kotlin/ch/kleis/lcaplugin/core/lang/evaluator/reducer/QuantityExpressionReducerTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/core/lang/evaluator/reducer/QuantityExpressionReducerTest.kt
@@ -9,9 +9,9 @@ import ch.kleis.lcaplugin.core.lang.fixture.DimensionFixture
 import ch.kleis.lcaplugin.core.lang.fixture.QuantityFixture
 import ch.kleis.lcaplugin.core.lang.fixture.UnitFixture
 import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
 import org.junit.Test
 import kotlin.math.pow
+import kotlin.test.assertFailsWith
 
 class QuantityExpressionReducerTest {
     /*
@@ -24,8 +24,8 @@ class QuantityExpressionReducerTest {
         val innerQuantity = QuantityFixture.oneKilogram
         val quantity = EQuantityScale(2.0, innerQuantity)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -42,8 +42,8 @@ class QuantityExpressionReducerTest {
         val innerQuantity = EQuantityRef("a")
         val quantity = EQuantityScale(2.0, innerQuantity)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -60,8 +60,8 @@ class QuantityExpressionReducerTest {
         val unit = EUnitOf(innerQuantity)
         val quantity = EQuantityLiteral(1.0, unit)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -77,9 +77,9 @@ class QuantityExpressionReducerTest {
         // given
         val quantityEnvironment = Register.empty<QuantityExpression>()
         val unitEnvironment: Register<UnitExpression> = Register.from(
-            hashMapOf(
-                Pair("kg", UnitFixture.kg)
-            )
+                hashMapOf(
+                        Pair("kg", UnitFixture.kg)
+                )
         )
         val quantity = EQuantityLiteral(1.0, EUnitRef("kg"))
         val reducer = QuantityExpressionReducer(quantityEnvironment, unitEnvironment)
@@ -98,8 +98,8 @@ class QuantityExpressionReducerTest {
         val a = EQuantityLiteral(2.0, UnitFixture.kg)
         val b = EQuantityLiteral(1000.0, UnitFixture.g)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -115,18 +115,17 @@ class QuantityExpressionReducerTest {
         // given
         val a = EQuantityLiteral(2.0, UnitFixture.kg)
         val b = EQuantityLiteral(1000.0, UnitFixture.m)
+        val quantity = EQuantityAdd(a, b)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when/then
-        try {
-            reducer.reduce(EQuantityAdd(a, b))
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            assertEquals("incompatible dimensions: mass vs length in left=2.0 kg and right=1000.0 m", e.message)
-        }
+        assertFailsWith(
+                EvaluatorException::class,
+                "incompatible dimensions: mass vs length in left=2.0 kg and right=1000.0 m"
+        ) { reducer.reduce(quantity) }
     }
 
     @Test
@@ -135,8 +134,8 @@ class QuantityExpressionReducerTest {
         val a = EQuantityLiteral(2.0, UnitFixture.kg)
         val b = EQuantityLiteral(1000.0, UnitFixture.g)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -153,17 +152,16 @@ class QuantityExpressionReducerTest {
         val a = EQuantityLiteral(2.0, UnitFixture.kg)
         val b = EQuantityLiteral(1000.0, UnitFixture.m)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
+        val eQuantitySub = EQuantitySub(a, b)
 
         // when/then
-        try {
-            reducer.reduce(EQuantitySub(a, b))
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            assertEquals("incompatible dimensions: mass vs length in left=2.0 kg and right=1000.0 m", e.message)
-        }
+        assertFailsWith(
+                EvaluatorException::class,
+                "incompatible dimensions: mass vs length in left=2.0 kg and right=1000.0 m"
+        ) { reducer.reduce(eQuantitySub) }
     }
 
     @Test
@@ -172,8 +170,8 @@ class QuantityExpressionReducerTest {
         val a = EQuantityLiteral(2.0, UnitFixture.person)
         val b = EQuantityLiteral(2.0, UnitFixture.km)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -181,12 +179,12 @@ class QuantityExpressionReducerTest {
 
         // then
         val expected = EQuantityLiteral(
-            4.0,
-            EUnitLiteral(
-                "person.km",
-                1.0 * 1000.0,
-                Dimension.None.multiply(DimensionFixture.length)
-            )
+                4.0,
+                EUnitLiteral(
+                        "person.km",
+                        1.0 * 1000.0,
+                        Dimension.None.multiply(DimensionFixture.length)
+                )
         )
         assertEquals(expected, actual)
     }
@@ -197,8 +195,8 @@ class QuantityExpressionReducerTest {
         val a = EQuantityLiteral(4.0, UnitFixture.km)
         val b = EQuantityLiteral(2.0, UnitFixture.hour)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -206,12 +204,12 @@ class QuantityExpressionReducerTest {
 
         // then
         val expected = EQuantityLiteral(
-            2.0,
-            EUnitLiteral(
-                "km/hour",
-                1000.0 / 3600.0,
-                DimensionFixture.length.divide(DimensionFixture.time)
-            )
+                2.0,
+                EUnitLiteral(
+                        "km/hour",
+                        1000.0 / 3600.0,
+                        DimensionFixture.length.divide(DimensionFixture.time)
+                )
         )
         assertEquals(expected, actual)
     }
@@ -221,8 +219,8 @@ class QuantityExpressionReducerTest {
         // given
         val a = EQuantityLiteral(4.0, UnitFixture.km)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -230,12 +228,12 @@ class QuantityExpressionReducerTest {
 
         // then
         val expected = EQuantityLiteral(
-            16.0,
-            EUnitLiteral(
-                "km^(2.0)",
-                1e6,
-                DimensionFixture.length.pow(2.0)
-            )
+                16.0,
+                EUnitLiteral(
+                        "km^(2.0)",
+                        1e6,
+                        DimensionFixture.length.pow(2.0)
+                )
         )
         assertEquals(expected, actual)
     }
@@ -245,12 +243,12 @@ class QuantityExpressionReducerTest {
         // given
         val a = EQuantityRef("a")
         val reducer = QuantityExpressionReducer(
-            Register.from(
-                hashMapOf(
-                    Pair("a", EQuantityLiteral(1.0, UnitFixture.kg))
-                )
-            ),
-            Register.empty(),
+                Register.from(
+                        hashMapOf(
+                                Pair("a", EQuantityLiteral(1.0, UnitFixture.kg))
+                        )
+                ),
+                Register.empty(),
         )
 
         // when
@@ -272,8 +270,8 @@ class QuantityExpressionReducerTest {
         val quantityConversion = EQuantityLiteral(2.2, kg)
         val unitComposition = EUnitAlias("lbs", quantityConversion)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
         // when
         val actual = reducer.reduceUnit(unitComposition)
@@ -289,8 +287,8 @@ class QuantityExpressionReducerTest {
         val quantityConversion = EQuantityLiteral(2200.0, g)
         val unitComposition = EUnitAlias("lbs", quantityConversion)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
         // when
         val actual = reducer.reduceUnit(unitComposition)
@@ -305,8 +303,8 @@ class QuantityExpressionReducerTest {
         val quantity = QuantityFixture.twoKilograms
         val unit = EUnitOf(quantity)
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -321,16 +319,16 @@ class QuantityExpressionReducerTest {
     fun reduce_whenUnitClosure_shouldReduceWithGivenTable() {
         // given
         val symbolTable = SymbolTable(
-            units = Register.from(
-                mapOf("a" to UnitFixture.kg)
-            )
+                units = Register.from(
+                        mapOf("a" to UnitFixture.kg)
+                )
         )
         val unit = EUnitClosure(symbolTable, EUnitRef("a"))
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.from(
-                mapOf("a" to UnitFixture.l)
-            )
+                Register.empty(),
+                Register.from(
+                        mapOf("a" to UnitFixture.l)
+                )
         )
 
         // when
@@ -346,8 +344,8 @@ class QuantityExpressionReducerTest {
         // given
         val kg = UnitFixture.kg
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -363,8 +361,8 @@ class QuantityExpressionReducerTest {
         val kg = UnitFixture.kg
         val l = UnitFixture.l
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -372,9 +370,9 @@ class QuantityExpressionReducerTest {
 
         // then
         val expected = EUnitLiteral(
-            "kg/l",
-            1.0 / 1.0e-3,
-            DimensionFixture.mass.divide(DimensionFixture.volume),
+                "kg/l",
+                1.0 / 1.0e-3,
+                DimensionFixture.mass.divide(DimensionFixture.volume),
         )
         assertEquals(expected, actual)
     }
@@ -385,8 +383,8 @@ class QuantityExpressionReducerTest {
         val kg = UnitFixture.kg
         val l = UnitFixture.l
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -394,9 +392,9 @@ class QuantityExpressionReducerTest {
 
         // then
         val expected = EUnitLiteral(
-            "kg.l",
-            1.0 * 1.0e-3,
-            DimensionFixture.mass.multiply(DimensionFixture.volume),
+                "kg.l",
+                1.0 * 1.0e-3,
+                DimensionFixture.mass.multiply(DimensionFixture.volume),
         )
         assertEquals(expected, actual)
     }
@@ -406,8 +404,8 @@ class QuantityExpressionReducerTest {
         // given
         val m = UnitFixture.m
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            Register.empty(),
+                Register.empty(),
+                Register.empty(),
         )
 
         // when
@@ -415,9 +413,9 @@ class QuantityExpressionReducerTest {
 
         // then
         val expected = EUnitLiteral(
-            "m^(2.0)",
-            1.0.pow(2.0),
-            DimensionFixture.length.pow(2.0),
+                "m^(2.0)",
+                1.0.pow(2.0),
+                DimensionFixture.length.pow(2.0),
         )
         assertEquals(expected, actual)
     }
@@ -427,13 +425,13 @@ class QuantityExpressionReducerTest {
         // given
         val ref = EUnitRef("kg")
         val units: Register<UnitExpression> = Register.from(
-            hashMapOf(
-                Pair("kg", UnitFixture.kg)
-            )
+                hashMapOf(
+                        Pair("kg", UnitFixture.kg)
+                )
         )
         val reducer = QuantityExpressionReducer(
-            Register.empty(),
-            units,
+                Register.empty(),
+                units,
         )
 
         // when

--- a/src/test/kotlin/ch/kleis/lcaplugin/core/lang/evaluator/step/ReduceAndCompleteTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/core/lang/evaluator/step/ReduceAndCompleteTest.kt
@@ -8,8 +8,8 @@ import ch.kleis.lcaplugin.core.lang.expression.*
 import ch.kleis.lcaplugin.core.lang.fixture.*
 import ch.kleis.lcaplugin.core.lang.value.*
 import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 
 class ReduceAndCompleteTest {
@@ -182,12 +182,10 @@ class ReduceAndCompleteTest {
         val reduceAndComplete = ReduceAndComplete(SymbolTable.empty())
 
         // when/then
-        try {
-            reduceAndComplete.apply(template)
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            assertEquals("unbounded references: [q_carrot, q_water]", e.message)
-        }
+        assertFailsWith(
+            EvaluatorException::class,
+            "unbounded references: [q_carrot, q_water]"
+        ) { reduceAndComplete.apply(template) }
     }
 
     @Test

--- a/src/test/kotlin/ch/kleis/lcaplugin/core/lang/expression/LcaExpressionTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/core/lang/expression/LcaExpressionTest.kt
@@ -2,8 +2,8 @@ package ch.kleis.lcaplugin.core.lang.expression
 
 import ch.kleis.lcaplugin.core.lang.evaluator.EvaluatorException
 import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class LcaExpressionTest {
     @Test
@@ -23,14 +23,8 @@ class LcaExpressionTest {
         // Given
         val name = "Bad"
 
-        // When
-        try {
-            SubstanceType.of(name)
-            fail("Should not pass")
-        } catch (e: EvaluatorException) {
-            // Then
-            assertEquals("Invalid SubstanceType: Bad", e.message)
-        }
+        // When / then
+        assertFailsWith(EvaluatorException::class, "Invalid SubstanceType: Bad") { SubstanceType.of(name) }
     }
 
 }

--- a/src/test/kotlin/ch/kleis/lcaplugin/core/lang/value/ExchangeValueTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/core/lang/value/ExchangeValueTest.kt
@@ -5,59 +5,52 @@ import ch.kleis.lcaplugin.core.lang.fixture.FullyQualifiedSubstanceValueFixture
 import ch.kleis.lcaplugin.core.lang.fixture.IndicatorValueFixture
 import ch.kleis.lcaplugin.core.lang.fixture.ProductValueFixture
 import ch.kleis.lcaplugin.core.lang.fixture.QuantityValueFixture
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class ExchangeValueTest {
     @Test
-    fun technoExchange_whenDimensionsDontMatch_thenThrows() {
+    fun technoExchange_whenDimensionsDoNotMatch_thenThrows() {
         // given
         val quantity = QuantityValueFixture.oneKilogram
         val product = ProductValueFixture.water
 
         // when/then
-        try {
-            TechnoExchangeValue(quantity, product)
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            assertEquals("incompatible dimensions: mass vs length³ for product water", e.message)
-        }
+        assertFailsWith(
+                EvaluatorException::class,
+                "incompatible dimensions: mass vs length³ for product water"
+        ) { TechnoExchangeValue(quantity, product) }
     }
 
     @Test
-    fun bioExchange_whenDimensionsDontMatch_thenThrows() {
+    fun bioExchange_whenDimensionsDoNotMatch_thenThrows() {
         // given
         val quantity = QuantityValueFixture.oneLitre
         val substance = FullyQualifiedSubstanceValueFixture.propanol
 
-        // when/then
-        try {
-            BioExchangeValue(quantity, substance)
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            assertEquals(
+        // when
+        val sut: () -> Unit = { BioExchangeValue(quantity, substance) }
+        assertFailsWith(
+                EvaluatorException::class,
                 "incompatible dimensions: length³ vs mass for substance [Resource] propanol(air), quantity=1.0",
-                e.message
-            )
-        }
+                sut
+        )
     }
 
     @Test
-    fun impact_whenDimensionsDontMatch_thenThrows() {
+    fun impact_whenDimensionsDoNotMatch_thenThrows() {
         // given
         val quantity = QuantityValueFixture.oneLitre
         val indicator = IndicatorValueFixture.climateChange
 
+        // When
+        val sut: () -> Unit = { ImpactValue(quantity, indicator) }
+
         // when/then
-        try {
-            ImpactValue(quantity, indicator)
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            assertEquals(
+        assertFailsWith(
+                EvaluatorException::class,
                 "incompatible dimensions: length³ vs mass for indicator climate change, quantity=1.0",
-                e.message
-            )
-        }
+                sut
+        )
     }
 }

--- a/src/test/kotlin/ch/kleis/lcaplugin/e2e/E2ETest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/e2e/E2ETest.kt
@@ -13,8 +13,7 @@ import ch.kleis.lcaplugin.language.parser.LcaLangAbstractParser
 import ch.kleis.lcaplugin.language.psi.LcaFile
 import com.intellij.psi.PsiManager
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import junit.framework.TestCase
-import org.junit.Assert
+import kotlin.test.assertFailsWith
 
 class E2ETest : BasePlatformTestCase() {
 
@@ -25,7 +24,7 @@ class E2ETest : BasePlatformTestCase() {
     fun test_substanceResolution() {
         val pkgName = "e2e.test_substanceResolution"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 process p {
@@ -65,13 +64,13 @@ class E2ETest : BasePlatformTestCase() {
                 val input = result.controllablePorts.getElements().first()
                 val cf = result.value(output, input)
 
-                TestCase.assertEquals("a from p{}", output.getDisplayName())
-                TestCase.assertEquals(1.0, cf.output.quantity().amount)
-                TestCase.assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.output.quantity().unit)
+                assertEquals("a from p{}", output.getDisplayName())
+                assertEquals(1.0, cf.output.quantity().amount)
+                assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.output.quantity().unit)
 
-                TestCase.assertEquals("co2", input.getDisplayName())
-                TestCase.assertEquals(1.0, cf.input.quantity().amount)
-                TestCase.assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.input.quantity().unit)
+                assertEquals("co2", input.getDisplayName())
+                assertEquals(1.0, cf.input.quantity().amount)
+                assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.input.quantity().unit)
             }
         }
     }
@@ -80,7 +79,7 @@ class E2ETest : BasePlatformTestCase() {
         // given
         val pkgName = "e2e.test_meta_whenKeywordAsKey"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 process p {
@@ -97,17 +96,17 @@ class E2ETest : BasePlatformTestCase() {
         val actual = file.getProcesses().first().getBlockMetaList().first().metaAssignmentList
 
         // then
-        TestCase.assertEquals("unit", actual[0].name)
-        TestCase.assertEquals("a", actual[0].getValue())
-        TestCase.assertEquals("process", actual[1].name)
-        TestCase.assertEquals("b", actual[1].getValue())
+        assertEquals("unit", actual[0].name)
+        assertEquals("a", actual[0].getValue())
+        assertEquals("process", actual[1].name)
+        assertEquals("b", actual[1].getValue())
     }
 
     fun test_operationPriority() {
         // given
         val pkgName = "e2e.test_operationPriority"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             
             process p {
@@ -139,13 +138,13 @@ class E2ETest : BasePlatformTestCase() {
                 val input = result.controllablePorts.getElements().first()
                 val cf = result.value(output, input)
 
-                TestCase.assertEquals("out from p{}", output.getDisplayName())
-                TestCase.assertEquals(1.0, cf.output.quantity().amount)
-                TestCase.assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.output.quantity().unit)
+                assertEquals("out from p{}", output.getDisplayName())
+                assertEquals(1.0, cf.output.quantity().amount)
+                assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.output.quantity().unit)
 
-                TestCase.assertEquals("in", input.getDisplayName())
-                TestCase.assertEquals(6.0, cf.input.quantity().amount)
-                TestCase.assertEquals(DimensionFixture.length.getDefaultUnitValue(), cf.input.quantity().unit)
+                assertEquals("in", input.getDisplayName())
+                assertEquals(6.0, cf.input.quantity().amount)
+                assertEquals(DimensionFixture.length.getDefaultUnitValue(), cf.input.quantity().unit)
             }
         }
     }
@@ -154,7 +153,7 @@ class E2ETest : BasePlatformTestCase() {
         // given
         val pkgName = "e2e.test_twoInstancesSameTemplate_whenOneImplicit"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             
             process office {
@@ -199,13 +198,13 @@ class E2ETest : BasePlatformTestCase() {
                 val input = result.controllablePorts.get("co2")
                 val cf = result.value(output, input)
 
-                TestCase.assertEquals("office from office{}", output.getDisplayName())
-                TestCase.assertEquals(1.0, cf.output.quantity().amount)
-                TestCase.assertEquals(Dimension.None.getDefaultUnitValue(), cf.output.quantity().unit)
+                assertEquals("office from office{}", output.getDisplayName())
+                assertEquals(1.0, cf.output.quantity().amount)
+                assertEquals(Dimension.None.getDefaultUnitValue(), cf.output.quantity().unit)
 
-                TestCase.assertEquals("co2", input.getDisplayName())
-                TestCase.assertEquals(3.0, cf.input.quantity().amount)
-                TestCase.assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.input.quantity().unit)
+                assertEquals("co2", input.getDisplayName())
+                assertEquals(3.0, cf.input.quantity().amount)
+                assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.input.quantity().unit)
             }
         }
     }
@@ -214,7 +213,7 @@ class E2ETest : BasePlatformTestCase() {
         // given
         val pkgName = "e2e.test_twoInstancesSameTemplate_whenExplicit"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             
             process office {
@@ -259,13 +258,13 @@ class E2ETest : BasePlatformTestCase() {
                 val input = result.controllablePorts.get("co2")
                 val cf = result.value(output, input)
 
-                TestCase.assertEquals("office from office{}", output.getDisplayName())
-                TestCase.assertEquals(1.0, cf.output.quantity().amount)
-                TestCase.assertEquals(Dimension.None.getDefaultUnitValue(), cf.output.quantity().unit)
+                assertEquals("office from office{}", output.getDisplayName())
+                assertEquals(1.0, cf.output.quantity().amount)
+                assertEquals(Dimension.None.getDefaultUnitValue(), cf.output.quantity().unit)
 
-                TestCase.assertEquals("co2", input.getDisplayName())
-                TestCase.assertEquals(3.0, cf.input.quantity().amount)
-                TestCase.assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.input.quantity().unit)
+                assertEquals("co2", input.getDisplayName())
+                assertEquals(3.0, cf.input.quantity().amount)
+                assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.input.quantity().unit)
             }
         }
     }
@@ -274,7 +273,7 @@ class E2ETest : BasePlatformTestCase() {
         // given
         val pkgName = "e2e.test_manyInstancesSameTemplate"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             
             process office {
@@ -325,13 +324,13 @@ class E2ETest : BasePlatformTestCase() {
                 val input = result.controllablePorts.get("co2")
                 val cf = result.value(output, input)
 
-                TestCase.assertEquals("office from office{}", output.getDisplayName())
-                TestCase.assertEquals(1.0, cf.output.quantity().amount)
-                TestCase.assertEquals(Dimension.None.getDefaultUnitValue(), cf.output.quantity().unit)
+                assertEquals("office from office{}", output.getDisplayName())
+                assertEquals(1.0, cf.output.quantity().amount)
+                assertEquals(Dimension.None.getDefaultUnitValue(), cf.output.quantity().unit)
 
-                TestCase.assertEquals("co2", input.getDisplayName())
-                TestCase.assertEquals(13.0, cf.input.quantity().amount)
-                TestCase.assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.input.quantity().unit)
+                assertEquals("co2", input.getDisplayName())
+                assertEquals(13.0, cf.input.quantity().amount)
+                assertEquals(DimensionFixture.mass.getDefaultUnitValue(), cf.input.quantity().unit)
             }
         }
     }
@@ -340,7 +339,7 @@ class E2ETest : BasePlatformTestCase() {
         // given
         val pkgName = "e2e.test_allocate"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             
             process p {
@@ -373,8 +372,8 @@ class E2ETest : BasePlatformTestCase() {
                 val cf2 = result.value(output2, input)
 
                 val delta = 1E-9
-                TestCase.assertEquals(0.9, cf1.input.quantity().amount, delta)
-                TestCase.assertEquals(0.1, cf2.input.quantity().amount, delta)
+                assertEquals(0.9, cf1.input.quantity().amount, delta)
+                assertEquals(0.1, cf2.input.quantity().amount, delta)
             }
         }
     }
@@ -383,7 +382,7 @@ class E2ETest : BasePlatformTestCase() {
         // given
         val pkgName = "e2e.test_allocate_whenOneProduct_allocateIsOptional"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             
             process p {
@@ -398,16 +397,16 @@ class E2ETest : BasePlatformTestCase() {
         // when
         val symbolTable = parser.load()
         val actual =
-            (((symbolTable.processTemplates["p"] as EProcessTemplate).body).products[0].allocation as EQuantityLiteral).amount
+                (((symbolTable.processTemplates["p"] as EProcessTemplate).body).products[0].allocation as EQuantityLiteral).amount
         // then
-        TestCase.assertEquals(100.0, actual)
+        assertEquals(100.0, actual)
     }
 
     fun test_allocate_whenSecondaryBlock_EmptyBlockIsAllowed() {
         // given
         val pkgName = "e2e.test_allocate_whenSecondaryBlock_EmptyBlockIsAllowed"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             
             process p {
@@ -424,16 +423,16 @@ class E2ETest : BasePlatformTestCase() {
         // when
         val symbolTable = parser.load()
         val actual =
-            (((symbolTable.processTemplates["p"] as EProcessTemplate).body).products[0].allocation as EQuantityLiteral).amount
+                (((symbolTable.processTemplates["p"] as EProcessTemplate).body).products[0].allocation as EQuantityLiteral).amount
         // then
-        TestCase.assertEquals(100.0, actual)
+        assertEquals(100.0, actual)
     }
 
     fun test_allocate_whenTwoProducts_shouldReturnWeightedResult() {
         // given
         val pkgName = "e2e.test_allocate_whenTwoProducts_shouldReturnWeightedResult"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             
             process p {
@@ -468,8 +467,8 @@ class E2ETest : BasePlatformTestCase() {
                 val delta = 1E-9
                 val expected1 = 1.0 * 20 / 100
                 val expected2 = 1.0 * 80 / 100
-                TestCase.assertEquals(expected1, cf1.input.quantity().amount, delta)
-                TestCase.assertEquals(expected2, cf2.input.quantity().amount, delta)
+                assertEquals(expected1, cf1.input.quantity().amount, delta)
+                assertEquals(expected2, cf2.input.quantity().amount, delta)
             }
         }
     }
@@ -478,7 +477,7 @@ class E2ETest : BasePlatformTestCase() {
         // given
         val pkgName = "e2e.test_unitAlias_whenInfiniteLoop_shouldThrowAnError"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             unit foo {
                 symbol = "foo"
@@ -496,20 +495,17 @@ class E2ETest : BasePlatformTestCase() {
         val parser = LcaLangAbstractParser(sequenceOf(file))
         val symbolTable = parser.load()
         val entryPoint = symbolTable.processTemplates["p"]!!
-        // when
-        try {
-            Evaluator(symbolTable).eval(entryPoint)
-            Assert.fail("Should fail")
-        } catch (e: EvaluatorException) {
-            Assert.assertEquals("Recursive dependency for unit foo", e.message)
-        }
+        val evaluator = Evaluator(symbolTable)
+
+        // when + then
+        assertFailsWith(EvaluatorException::class, "Recursive dependency for unit foo", { evaluator.eval(entryPoint) })
     }
 
     fun test_unitAlias_whenNestedInfiniteLoop_shouldThrowAnError() {
         // given
         val pkgName = "e2e.test_unitAlias_whenNestedInfiniteLoop_shouldThrowAnError"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             
             unit bar {
@@ -533,20 +529,17 @@ class E2ETest : BasePlatformTestCase() {
         val parser = LcaLangAbstractParser(sequenceOf(file))
         val symbolTable = parser.load()
         val entryPoint = symbolTable.processTemplates["p"]!!
-        // when
-        try {
-            Evaluator(symbolTable).eval(entryPoint)
-            Assert.fail("Should fail")
-        } catch (e: EvaluatorException) {
-            Assert.assertEquals("Recursive dependency for unit foo", e.message)
-        }
+        val evaluator = Evaluator(symbolTable)
+
+        // when + then
+        assertFailsWith(EvaluatorException::class, "Recursive dependency for unit foo", { evaluator.eval(entryPoint) })
     }
 
     fun test_unitAlias_shouldNotThrowAnError() {
         // given
         val pkgName = "e2e.test_unitAlias_shouldNotThrowAnError"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             
             unit bar {
@@ -570,19 +563,17 @@ class E2ETest : BasePlatformTestCase() {
         val parser = LcaLangAbstractParser(sequenceOf(file))
         val symbolTable = parser.load()
         val entryPoint = symbolTable.processTemplates["p"]!!
-        // when
-        try {
-            Evaluator(symbolTable).eval(entryPoint)
-        } catch (e: EvaluatorException) {
-            Assert.fail("Should not fail")
-        }
+        val evaluator = Evaluator(symbolTable)
+
+        // when, then does not throw
+        evaluator.eval(entryPoint)
     }
 
     fun test_unitAlias_whenAdditionInAliasForField_shouldNotThrowAnError() {
         // given
         val pkgName = "e2e.test_unitAlias_whenAdditionInAliasForField_shouldNotThrowAnError"
         val vf = myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
             package $pkgName
             
             unit bar {

--- a/src/test/kotlin/ch/kleis/lcaplugin/imports/simapro/UnitRendererTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/imports/simapro/UnitRendererTest.kt
@@ -7,12 +7,13 @@ import ch.kleis.lcaplugin.imports.ImportException
 import ch.kleis.lcaplugin.imports.ModelWriter
 import io.mockk.*
 import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.fail
 import org.junit.After
+
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.openlca.simapro.csv.refdata.UnitRow
+import kotlin.test.assertFailsWith
 
 class UnitRendererTest {
 
@@ -184,17 +185,10 @@ class UnitRendererTest {
             .quantity("Time")
             .conversionFactor(1.0)
             .referenceUnit("kg")
+        val message = "A Unit kg for kg already exists with another dimension, time is not compatible with mass."
 
         // When + Then
-        try {
-            sut.render(data, writer)
-            fail("Should not pass !")
-        } catch (e: ImportException) {
-            assertEquals(
-                "A Unit kg for kg already exists with another dimension, time is not compatible with mass.",
-                e.message
-            )
-        }
+        assertFailsWith(ImportException::class, message) { sut.render(data, writer) }
     }
 
     @Test
@@ -205,17 +199,10 @@ class UnitRendererTest {
             .quantity("mass")
             .conversionFactor(1.0)
             .referenceUnit("kg")
+        val message = "Unit kg is referencing itself in its own declaration"
 
         // When + Then
-        try {
-            sut.render(data, writer)
-            fail("Should not pass !")
-        } catch (e: ImportException) {
-            assertEquals(
-                "Unit kg is referencing itself in its own declaration",
-                e.message
-            )
-        }
+        assertFailsWith(ImportException::class, message) { sut.render(data, writer) }
     }
 
     @Test

--- a/src/test/kotlin/ch/kleis/lcaplugin/language/parser/LcaLangAbstractParserTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/language/parser/LcaLangAbstractParserTest.kt
@@ -11,12 +11,18 @@ import ch.kleis.lcaplugin.core.prelude.Prelude
 import ch.kleis.lcaplugin.language.psi.LcaFile
 import com.intellij.testFramework.ParsingTestCase
 import junit.framework.TestCase
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import kotlin.test.assertFailsWith
 
+@RunWith(JUnit4::class)
 class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition()) {
+    @Test
     fun testParse_shouldLoadUnitAlias() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
             unit lbs {
                 symbol = "lbs"
                 alias_for = 2.2 kg
@@ -24,7 +30,7 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
         // when
         val symbolTable = parser.load()
@@ -34,14 +40,15 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         assertEquals(expect, actual)
     }
 
+    @Test
     fun testParse_shouldLoadPreludeUnits() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when
@@ -51,14 +58,15 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         TestCase.assertEquals(Prelude.units, symbolTable.units)
     }
 
+    @Test
     fun testParse_shouldLoadPreludeUnitQuantities() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when
@@ -68,10 +76,11 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         TestCase.assertEquals(Prelude.unitQuantities, symbolTable.quantities)
     }
 
+    @Test
     fun testParse_blockUnit_shouldDeclareUnitRefAndQuantityRef() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
                 unit foo {
                     symbol = "foo"
                     dimension = "foo"
@@ -79,7 +88,7 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
         val symbolTable = parser.load()
 
@@ -92,10 +101,11 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         TestCase.assertEquals(quantity.amount, 1.0)
     }
 
+    @Test
     fun testParse_referenceStartingWithUnderscore_shouldParse() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
                 variables {
                     _1kg = 1 kg
                 }
@@ -104,16 +114,17 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
 
         // when
         val actual = file.getPsiGlobalVariablesBlocks().first()
-            .getGlobalAssignments().first().getQuantityRef().getUID()
+                .getGlobalAssignments().first().getQuantityRef().getUID()
 
         // then
         val expected = "_1kg"
         TestCase.assertEquals(expected, actual.name)
     }
 
+    @Test
     fun testParse_processWithLandUse_shouldParse() {
         val file = parseFile(
-            "hello", """
+                "hello", """
                 process a {
                     products {
                         1 kg x
@@ -125,27 +136,28 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
         val symbolTable = parser.load()
 
         // when
         val template = symbolTable.processTemplates["a"] as ProcessTemplateExpression
         val actual =
-            (ProcessTemplateExpression.eProcessTemplate.body.biosphere compose
-                    Every.list() compose EBioExchange.substance).firstOrNull(template)
+                (ProcessTemplateExpression.eProcessTemplate.body.biosphere compose
+                        Every.list() compose EBioExchange.substance).firstOrNull(template)
 
         // then
         TestCase.assertEquals("lu", actual?.name)
     }
 
+    @Test
     fun testParse_substance_shouldParseFields() {
         val subName = "co2"
         val type = SubstanceType.RESOURCE
         val compartment = "air"
         val subCompartment = "low pop"
         val file = parseFile(
-            "hello", """
+                "hello", """
                 substance $subName {
                     name = "carbon dioxide"
                     type = $type
@@ -160,10 +172,10 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
 
         // when
         val actual = symbolTable.getSubstanceCharacterization(
-            name = subName,
-            type = type,
-            compartment = compartment,
-            subCompartment = subCompartment,
+                name = subName,
+                type = type,
+                compartment = compartment,
+                subCompartment = subCompartment,
         )!!.referenceExchange.substance
 
         // then
@@ -174,10 +186,11 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         TestCase.assertEquals(EUnitRef("kg"), actual.referenceUnit)
     }
 
+    @Test
     fun testParse_whenDefineProcessTwice_shouldThrow() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
                 process a {
                 }
                 process a {
@@ -185,25 +198,18 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when/then
-        try {
-            parser.load()
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            TestCase.assertEquals(
-                "[a] are already bound",
-                e.message
-            )
-        }
+        assertFailsWith(EvaluatorException::class, "[a] are already bound") { parser.load() }
     }
 
+    @Test
     fun testParse_whenDefineProductTwice_shouldThrow() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
                 process a {
                     products {
                         1 kg x
@@ -217,25 +223,18 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when/then
-        try {
-            parser.load()
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            TestCase.assertEquals(
-                "x is already bound",
-                e.message
-            )
-        }
+        assertFailsWith(EvaluatorException::class, "x is already bound") { parser.load() }
     }
 
+    @Test
     fun testParse_withoutPackage_thenDefaultPackageName() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
         """.trimIndent()
         ) as LcaFile
 
@@ -247,10 +246,11 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         TestCase.assertEquals(expected, actual)
     }
 
+    @Test
     fun testParse_whenDefineGlobalVariableTwice_shouldThrow() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
                 variables {
                     x = 1 kg
                     x = 3 l
@@ -258,22 +258,18 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when/then
-        try {
-            parser.load()
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            TestCase.assertEquals("[x] are already bound", e.message)
-        }
+        assertFailsWith(EvaluatorException::class, "[x] are already bound") { parser.load() }
     }
 
-    fun testParse_whenDefineSameSubstanceTwice_shouldThrow() {
+    @Test
+    fun testParse_whenDefineSubstanceTwice_shouldThrow() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
                 substance a {
                     name = "first"
                     type = Resource
@@ -289,25 +285,18 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when/then
-        try {
-            parser.load()
-            fail("should have thrown")
-        } catch (e: EvaluatorException) {
-            TestCase.assertEquals(
-                "[a_compartment_Resource] are already bound",
-                e.message
-            )
-        }
+        assertFailsWith(EvaluatorException::class, "[a] are already bound") { parser.load() }
     }
 
+    @Test
     fun testParse_whenDefineSameSubstanceDifferentSubCompartments_shouldNotThrow() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
                 substance a {
                     name = "first"
                     type = Resource
@@ -324,21 +313,18 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
-        // when/then
-        try {
-            parser.load()
-        } catch (e: EvaluatorException) {
-            fail("Threw: $e")
-        }
+        // when, then should not throw
+        parser.load()
     }
 
+    @Test
     fun testParse_withPackage_shouldReturnGivenPackageName() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
                 package a.b.c
         """.trimIndent()
         ) as LcaFile
@@ -351,10 +337,11 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         TestCase.assertEquals(expected, actual)
     }
 
+    @Test
     fun testParse_simpleProcess() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
             process a {
                 products {
                     1 kg carrot
@@ -366,7 +353,7 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when
@@ -375,46 +362,47 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
 
         // then
         val preludeSymbolTable = SymbolTable(
-            units = Prelude.units,
-            quantities = Prelude.unitQuantities,
+                units = Prelude.units,
+                quantities = Prelude.unitQuantities,
         )
         val expected = EProcessTemplate(
-            params = emptyMap(),
-            locals = emptyMap(),
-            EProcess(
-                name = "a",
-                products = listOf(
-                    ETechnoExchange(
-                        EQuantityScale(1.0, EQuantityRef("kg")),
-                        EProductSpec(
-                            "carrot",
-                            EUnitClosure(
-                                preludeSymbolTable, EUnitOf(
-                                    EQuantityScale(1.0, EQuantityRef("kg")),
-                                )
-                            )
+                params = emptyMap(),
+                locals = emptyMap(),
+                EProcess(
+                        name = "a",
+                        products = listOf(
+                                ETechnoExchange(
+                                        EQuantityScale(1.0, EQuantityRef("kg")),
+                                        EProductSpec(
+                                                "carrot",
+                                                EUnitClosure(
+                                                        preludeSymbolTable, EUnitOf(
+                                                        EQuantityScale(1.0, EQuantityRef("kg")),
+                                                )
+                                                )
+                                        ),
+                                ),
                         ),
-                    ),
-                ),
-                inputs = listOf(
-                    ETechnoExchange(
-                        EQuantityScale(10.0, EQuantityRef("l")),
-                        EProductSpec("water"),
-                    ),
-                ),
-                biosphere = emptyList(),
-            )
+                        inputs = listOf(
+                                ETechnoExchange(
+                                        EQuantityScale(10.0, EQuantityRef("l")),
+                                        EProductSpec("water"),
+                                ),
+                        ),
+                        biosphere = emptyList(),
+                )
         )
         TestCase.assertEquals(expected, actual)
     }
 
+    @Test
     fun testParse_unitExpression_div() {
         // given
         val subName = "a"
         val type = SubstanceType.RESOURCE
         val compartment = "compartment"
         val file = parseFile(
-            "hello", """
+                "hello", """
             substance $subName {
                 name = "a"
                 type = $type
@@ -424,33 +412,34 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when
         val symbolTable = parser.load()
         val substance = symbolTable.getSubstanceCharacterization(
-            name = subName,
-            type = type,
-            compartment = compartment,
+                name = subName,
+                type = type,
+                compartment = compartment,
         )!!.referenceExchange.substance
         val actual = substance.referenceUnit!!
 
         // then
         val expected = EUnitDiv(
-            EUnitRef("x"),
-            EUnitRef("y"),
+                EUnitRef("x"),
+                EUnitRef("y"),
         )
         TestCase.assertEquals(expected, actual)
     }
 
+    @Test
     fun testParse_unitExpression_mul() {
         // given
         val subName = "a"
         val type = SubstanceType.RESOURCE
         val compartment = "compartment"
         val file = parseFile(
-            "hello", """
+                "hello", """
             substance $subName {
                 name = "a"
                 type = $type
@@ -460,30 +449,31 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when
         val symbolTable = parser.load()
         val substance = symbolTable.getSubstanceCharacterization(
-            name = subName,
-            type = type,
-            compartment = compartment,
+                name = subName,
+                type = type,
+                compartment = compartment,
         )!!.referenceExchange.substance
         val actual = substance.referenceUnit!!
 
         // then
         val expected = EUnitMul(
-            EUnitRef("x"),
-            EUnitRef("y"),
+                EUnitRef("x"),
+                EUnitRef("y"),
         )
         TestCase.assertEquals(expected, actual)
     }
 
+    @Test
     fun testParse_quantityExpression_div() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
             process a {
                 inputs {
                     10 x / (20 y) water
@@ -492,7 +482,7 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when
@@ -505,16 +495,17 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
 
         // then
         val expected = EQuantityDiv(
-            EQuantityScale(10.0, EQuantityRef("x")),
-            EQuantityScale(20.0, EQuantityRef("y"))
+                EQuantityScale(10.0, EQuantityRef("x")),
+                EQuantityScale(20.0, EQuantityRef("y"))
         )
         TestCase.assertEquals(expected, actual)
     }
 
+    @Test
     fun testParse_quantityExpression_mul() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
             process a {
                 inputs {
                     10 x * (20 y) water
@@ -523,7 +514,7 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when
@@ -536,16 +527,17 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
 
         // then
         val expected = EQuantityMul(
-            EQuantityScale(10.0, EQuantityRef("x")),
-            EQuantityScale(20.0, EQuantityRef("y"))
+                EQuantityScale(10.0, EQuantityRef("x")),
+                EQuantityScale(20.0, EQuantityRef("y"))
         )
         TestCase.assertEquals(expected, actual)
     }
 
+    @Test
     fun testParse_withConstrainedProduct() {
         // given
         val file = parseFile(
-            "hello", """
+                "hello", """
             process a {
                 products {
                     1 kg carrot
@@ -557,31 +549,32 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when
         val symbolTable = parser.load()
         val expression = symbolTable.getTemplate("a")!!
         val actual =
-            ProcessTemplateExpression.eProcessTemplate.body.inputs.getAll(expression).flatten()
+                ProcessTemplateExpression.eProcessTemplate.body.inputs.getAll(expression).flatten()
 
         // then
         val expected = listOf(
-            ETechnoExchange(
-                EQuantityScale(10.0, EQuantityRef("l")),
-                EProductSpec(
-                    "water",
-                    fromProcessRef = FromProcessRef(
-                        "water_proc",
-                        mapOf("x" to EQuantityScale(3.0, EQuantityRef("l"))),
-                    ),
-                )
-            ),
+                ETechnoExchange(
+                        EQuantityScale(10.0, EQuantityRef("l")),
+                        EProductSpec(
+                                "water",
+                                fromProcessRef = FromProcessRef(
+                                        "water_proc",
+                                        mapOf("x" to EQuantityScale(3.0, EQuantityRef("l"))),
+                                ),
+                        )
+                ),
         )
         TestCase.assertEquals(expected, actual)
     }
 
+    @Test
     fun testParse_substanceWithImpacts_shouldReturnASubstanceCharacterization() {
         // given
         val name = "phosphate"
@@ -589,7 +582,7 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         val compartment = "phosphate compartment"
         val subCompartment = "phosphate sub-compartment"
         val file = parseFile(
-            "substances", """
+                "substances", """
             substance $name {
                 name = "phosphate"
                 type = $type
@@ -604,44 +597,45 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
 
         // when
         val symbolTable = parser.load()
         val actual = symbolTable.getSubstanceCharacterization(
-            name = name,
-            type = type,
-            compartment = compartment,
-            subCompartment = subCompartment
+                name = name,
+                type = type,
+                compartment = compartment,
+                subCompartment = subCompartment
         )
 
         // then
         val expected = ESubstanceCharacterization(
-            referenceExchange = EBioExchange(
-                EQuantityLiteral(1.0, EUnitRef("kg")),
-                ESubstanceSpec(
-                    name = "phosphate",
-                    type = SubstanceType.RESOURCE,
-                    compartment = "phosphate compartment",
-                    subCompartment = "phosphate sub-compartment",
-                    referenceUnit = EUnitRef("kg"),
+                referenceExchange = EBioExchange(
+                        EQuantityLiteral(1.0, EUnitRef("kg")),
+                        ESubstanceSpec(
+                                name = "phosphate",
+                                type = SubstanceType.RESOURCE,
+                                compartment = "phosphate compartment",
+                                subCompartment = "phosphate sub-compartment",
+                                referenceUnit = EUnitRef("kg"),
+                        ),
                 ),
-            ),
-            impacts = listOf(
-                EImpact(
-                    EQuantityScale(1.0, EQuantityRef("kg")),
-                    EIndicatorSpec("climate_change"),
+                impacts = listOf(
+                        EImpact(
+                                EQuantityScale(1.0, EQuantityRef("kg")),
+                                EIndicatorSpec("climate_change"),
+                        )
                 )
-            )
         )
         TestCase.assertEquals(expected, actual)
     }
 
+    @Test
     fun testParse_productWithoutAllocation_should_return_100percent_allocation() {
         // given
         val file = parseFile(
-            "carrot", """
+                "carrot", """
             process carrot {
                 products {
                     1 kg carrot
@@ -650,31 +644,32 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
         // when
         val symbolTable = parser.load()
         // then
         val actual = ((symbolTable.processTemplates["carrot"] as EProcessTemplate).body).products[0]
         val preludeSymbolTable = SymbolTable(
-            units = Prelude.units,
-            quantities = Prelude.unitQuantities,
+                units = Prelude.units,
+                quantities = Prelude.unitQuantities,
         )
         val expect = ETechnoExchange(
-            EQuantityScale(1.0, EQuantityRef("kg")),
-            EProductSpec(
-                "carrot",
-                EUnitClosure(preludeSymbolTable, EUnitOf(EQuantityScale(1.0, EQuantityRef("kg"))))
-            ),
-            EQuantityLiteral(100.0, EUnitLiteral("percent", 0.01, Dimension.None))
+                EQuantityScale(1.0, EQuantityRef("kg")),
+                EProductSpec(
+                        "carrot",
+                        EUnitClosure(preludeSymbolTable, EUnitOf(EQuantityScale(1.0, EQuantityRef("kg"))))
+                ),
+                EQuantityLiteral(100.0, EUnitLiteral("percent", 0.01, Dimension.None))
         )
         assertEquals(expect, actual)
     }
 
+    @Test
     fun testParse_productWithAllocation() {
         // given
         val file = parseFile(
-            "carrot", """
+                "carrot", """
             process carrot {
                 products {
                     1 kg carrot allocate 10 percent
@@ -683,23 +678,23 @@ class LcaLangAbstractParserTest : ParsingTestCase("", "lca", LcaParserDefinition
         """.trimIndent()
         ) as LcaFile
         val parser = LcaLangAbstractParser(
-            sequenceOf(file)
+                sequenceOf(file)
         )
         // when
         val symbolTable = parser.load()
         // then
         val actual = ((symbolTable.processTemplates["carrot"] as EProcessTemplate).body).products[0]
         val preludeSymbolTable = SymbolTable(
-            units = Prelude.units,
-            quantities = Prelude.unitQuantities,
+                units = Prelude.units,
+                quantities = Prelude.unitQuantities,
         )
         val expect = ETechnoExchange(
-            EQuantityScale(1.0, EQuantityRef("kg")),
-            EProductSpec(
-                "carrot",
-                EUnitClosure(preludeSymbolTable, EUnitOf(EQuantityScale(1.0, EQuantityRef("kg"))))
-            ),
-            EQuantityScale(10.0, EQuantityRef("percent"))
+                EQuantityScale(1.0, EQuantityRef("kg")),
+                EProductSpec(
+                        "carrot",
+                        EUnitClosure(preludeSymbolTable, EUnitOf(EQuantityScale(1.0, EQuantityRef("kg"))))
+                ),
+                EQuantityScale(10.0, EQuantityRef("percent"))
         )
         assertEquals(expect, actual)
     }

--- a/src/test/kotlin/ch/kleis/lcaplugin/language/type_checker/PsiLcaTypeCheckerTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/language/type_checker/PsiLcaTypeCheckerTest.kt
@@ -12,9 +12,14 @@ import ch.kleis.lcaplugin.language.psi.stub.unit.UnitKeyIndex
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import kotlin.test.assertFailsWith
 
+@RunWith(JUnit4::class)
 class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
-    override fun getTestDataPath(): String {
+    override
+    fun getTestDataPath(): String {
         return "testdata"
     }
 
@@ -23,7 +28,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenCircularDependencyInUnitDefinition_shouldThrowTypeCheckException"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -41,15 +46,10 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         val checker = PsiLcaTypeChecker()
 
         // when/then
-        try {
-            checker.check(target)
-            fail("should have thrown")
-        } catch (e: PsiTypeCheckException) {
-            TestCase.assertEquals(
-                """circular dependencies: "1 bar ...", "1 bar ...", "1 bar ...", "1 bar ...", "1 foo ...", "1 foo ...", "1""",
-                e.message
-            )
-        }
+        assertFailsWith(
+                PsiTypeCheckException::class,
+                """circular dependencies: "1 bar ...", "1 bar ...", "1 bar ...", "1 bar ...", "1 foo ...", "1 foo ...", "1"""
+        ) { checker.check(target) }
     }
 
     @Test
@@ -57,7 +57,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenUnitLiteral"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -82,7 +82,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenUnitAlias"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -112,7 +112,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenUnitAlias_div"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -147,7 +147,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenUnitAlias_mul"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -182,7 +182,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenUnitAlias_addition_sameDim"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -217,7 +217,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenUnitAlias_subtraction_sameDim"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -252,7 +252,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenUnitAlias_addition_differentDim_shouldThrow"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -275,11 +275,8 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         val checker = PsiLcaTypeChecker()
 
         // when/then
-        try {
+        assertFailsWith(PsiTypeCheckException::class, "incompatible dimensions: foo_dim vs foo2_dim") {
             checker.check(target)
-            fail("should have thrown")
-        } catch (e: PsiTypeCheckException) {
-            TestCase.assertEquals("incompatible dimensions: foo_dim vs foo2_dim", e.message)
         }
     }
 
@@ -288,7 +285,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenUnitAlias_withParenthesis"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -323,7 +320,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenUnitAlias_refToGlobalAssignment"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -357,7 +354,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenUnitAlias_directRef"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -391,7 +388,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenUnitAlias_directRef"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -420,7 +417,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenGlobalAssignment_addition_sameDim"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -449,7 +446,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenGlobalAssignment_addition_sameDim"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -478,7 +475,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenGlobalAssignment_addition_sameDim"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -512,7 +509,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenGlobalAssignment_addition_sameDim"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -546,7 +543,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenGlobalAssignment_addition_differentDim"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -568,11 +565,10 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         val checker = PsiLcaTypeChecker()
 
         // when/then
-        try {
-            checker.check(target)
-            fail("should have thrown")
-        } catch (e: PsiTypeCheckException) {
-            TestCase.assertEquals("incompatible dimensions: foo_dim vs foo2_dim", e.message)
+        assertFailsWith(PsiTypeCheckException::class, "incompatible dimensions: foo_dim vs foo2_dim") {
+            checker.check(
+                    target
+            )
         }
     }
 
@@ -581,7 +577,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenLocalAssignment"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -597,8 +593,8 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
             """.trimIndent()
         )
         val target = ProcessStubKeyIndex.findProcesses(project, "$pkgName.p").first()
-            .getPsiVariablesBlocks().first()
-            .getAssignments().first()
+                .getPsiVariablesBlocks().first()
+                .getAssignments().first()
         val checker = PsiLcaTypeChecker()
 
         // when
@@ -614,7 +610,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenLocalAssignment"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -630,8 +626,8 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
             """.trimIndent()
         )
         val target = ProcessStubKeyIndex.findProcesses(project, "$pkgName.p").first()
-            .getPsiParametersBlocks().first()
-            .getAssignments().first()
+                .getPsiParametersBlocks().first()
+                .getAssignments().first()
         val checker = PsiLcaTypeChecker()
 
         // when
@@ -647,7 +643,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenLocalAssignment"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -663,7 +659,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
             """.trimIndent()
         )
         val target = ProcessStubKeyIndex.findProcesses(project, "$pkgName.p").first()
-            .getInputs().first()
+                .getInputs().first()
         val checker = PsiLcaTypeChecker()
 
         // when
@@ -679,7 +675,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenLocalAssignment"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -706,16 +702,14 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
             """.trimIndent()
         )
         val target = ProcessStubKeyIndex.findProcesses(project, "$pkgName.p").first()
-            .getInputs().first()
+                .getInputs().first()
         val checker = PsiLcaTypeChecker()
 
         // when/then
-        try {
-            checker.check(target)
-            fail("should have thrown")
-        } catch (e: PsiTypeCheckException) {
-            TestCase.assertEquals("incompatible dimensions: foo_dim vs mass", e.message)
-        }
+        assertFailsWith(
+                PsiTypeCheckException::class,
+                "incompatible dimensions: foo_dim vs mass"
+        ) { checker.check(target) }
     }
 
     @Test
@@ -723,7 +717,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenTechnoInputExchange_wrongDimInArgument_shouldThrow"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 unit foo {
@@ -753,16 +747,14 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
             """.trimIndent()
         )
         val target = ProcessStubKeyIndex.findProcesses(project, "$pkgName.p").first()
-            .getInputs().first()
+                .getInputs().first()
         val checker = PsiLcaTypeChecker()
 
         // when/then
-        try {
-            checker.check(target)
-            fail("should have thrown")
-        } catch (e: PsiTypeCheckException) {
-            TestCase.assertEquals("incompatible dimensions: expecting foo_dim, found mass", e.message)
-        }
+        assertFailsWith(
+                PsiTypeCheckException::class,
+                "incompatible dimensions: expecting foo_dim, found mass"
+        ) { checker.check(target) }
     }
 
     @Test
@@ -770,7 +762,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
         // given
         val pkgName = """test_whenPreludeUnit"""
         myFixture.createFile(
-            "$pkgName.lca", """
+                "$pkgName.lca", """
                 package $pkgName
                 
                 process p {
@@ -781,7 +773,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
             """.trimIndent()
         )
         val target = ProcessStubKeyIndex.findProcesses(project, "$pkgName.p").first()
-            .getInputs().first()
+                .getInputs().first()
         val checker = PsiLcaTypeChecker()
 
         // when
@@ -789,7 +781,7 @@ class PsiLcaTypeCheckerTest : BasePlatformTestCase() {
 
         // then
         val expected = TTechnoExchange(
-            TProduct("foo_product", Prelude.mass)
+                TProduct("foo_product", Prelude.mass)
         )
         TestCase.assertEquals(expected, actual)
     }


### PR DESCRIPTION
A suitable assertion for Exception handling exists in kotlin.test - after discussion with @pke, it was deemed worthy of spending a little hour to use it to clean up the tests (ask me for the regular expressions :p).