### PR TITLE
Integrate feedback from demo on error messages.

### DIFF
--- a/src/main/kotlin/ch/kleis/lcaplugin/language/ide/insight/LcaAssignmentAnnotator.kt
+++ b/src/main/kotlin/ch/kleis/lcaplugin/language/ide/insight/LcaAssignmentAnnotator.kt
@@ -16,7 +16,7 @@ class LcaAssignmentAnnotator : Annotator {
                     annotateErrWithMessage(element, holder, "Quantity reference ${element.name} is already defined in the unit prelude.")
 
                 element.reference.multiResolve(false).size > 1 ->
-                    annotateErrWithMessage(element, holder, "This name is already defined somewhere else")
+                    annotateErrWithMessage(element, holder, "This name is already defined")
             }
         }
     }

--- a/src/test/kotlin/ch/kleis/lcaplugin/language/ide/insight/LcaAssignmentAnnotatorTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/language/ide/insight/LcaAssignmentAnnotatorTest.kt
@@ -93,7 +93,7 @@ class LcaAssignmentAnnotatorTest : BasePlatformTestCase() {
         annotator.annotate(element, mock.holder)
 
         // then
-        verify { mock.holder.newAnnotation(HighlightSeverity.ERROR, "This name is already defined somewhere else") }
+        verify { mock.holder.newAnnotation(HighlightSeverity.ERROR, "This name is already defined") }
         verify { mock.builder.range(element) }
         verify { mock.builder.highlightType(ProblemHighlightType.ERROR) }
         verify { mock.builder.create() }
@@ -197,7 +197,7 @@ class LcaAssignmentAnnotatorTest : BasePlatformTestCase() {
         annotator.annotate(element, mock.holder)
 
         // then
-        verify { mock.holder.newAnnotation(HighlightSeverity.ERROR, "This name is already defined somewhere else") }
+        verify { mock.holder.newAnnotation(HighlightSeverity.ERROR, "This name is already defined") }
         verify { mock.builder.range(element) }
         verify { mock.builder.highlightType(ProblemHighlightType.ERROR) }
         verify { mock.builder.create() }


### PR DESCRIPTION
Fix #224 : Remove "somewhere else" in error messages.