### PR TITLE
fix: dimension.toString() displays "dimensionless" when dimension is …

### DIFF
--- a/src/main/kotlin/ch/kleis/lcaplugin/core/lang/dimension/Dimension.kt
+++ b/src/main/kotlin/ch/kleis/lcaplugin/core/lang/dimension/Dimension.kt
@@ -9,6 +9,9 @@ class Dimension(
     private val elements: Map<String, Double>
 
     override fun toString(): String {
+        if (elements.isEmpty()) {
+            return "dimensionless"
+        }
         return elements.entries.joinToString(".") {
             simpleDimToString(it)
         }

--- a/src/test/kotlin/ch/kleis/lcaplugin/core/lang/dimension/DimensionTest.kt
+++ b/src/test/kotlin/ch/kleis/lcaplugin/core/lang/dimension/DimensionTest.kt
@@ -1,0 +1,44 @@
+package ch.kleis.lcaplugin.core.lang.dimension
+
+import kotlin.test.assertEquals
+import org.junit.Test
+
+
+class DimensionTest {
+
+    @Test
+    fun test_toString_whenNone() {
+        // given
+        val dimension = Dimension.None
+
+        // when
+        val actual = "$dimension"
+
+        // then
+        assertEquals("dimensionless", actual)
+    }
+
+    @Test
+    fun test_toString_whenSimpleDim() {
+        // given
+        val dimension = Dimension.of("something")
+
+        // when
+        val actual ="$dimension"
+
+        // then
+        assertEquals("something", actual)
+    }
+
+    @Test
+    fun test_toString_whenSmallPower() {
+        // given
+        val dimension = Dimension.of("something", 2)
+
+        // when
+        val actual ="$dimension"
+
+        // then
+        assertEquals("something²", actual)
+    }
+}


### PR DESCRIPTION
#248 