### PR TITLE
Fix/sensitivity analysis

### DIFF
--- a/src/main/kotlin/ch/kleis/lcaplugin/core/assessment/SensitivityAnalysis.kt
+++ b/src/main/kotlin/ch/kleis/lcaplugin/core/assessment/SensitivityAnalysis.kt
@@ -48,9 +48,9 @@ class SensitivityAnalysis(
         parameter: ParameterName,
     ): Double {
         val parameterIndex = parameters.indexOf(parameter)
-        val impactFactor = impactFactors.unitaryImpact(target, indicator).amount
-        val base = impactFactor.zeroth
-        val absoluteSensibility = impactFactor.first[parameterIndex]
+        val impact = getPortContribution(target, indicator).amount
+        val base = impact.zeroth
+        val absoluteSensibility = impact.first[parameterIndex]
         return absoluteSensibility / base
     }
 


### PR DESCRIPTION
Aujourd'hui, on analyse la sensibilité de l'impact **unitaire** d'un produit, et non pas sa contribution totale..

La distinction est visible dans un cas comme suit:

```
process average {
  params {
    x = 1 kg // ss-entendu x = 1 kg . (1 + dx)
    y = 1 kg // ss-entendu y = 1 kg . (1 + dy)
  }
 products {
    x + y out
  }
 inputs {
    x inputX
  2 u * y inputY
  }
}
```

En supposant que inputX et inputY ont un impact unitaire de 1 kgCO2e, l'impact total est 

```
Q = x + 2y
    = 3 kg (1 + dx + 2dy)
```

tandis que l'impact unitaire est 
```
q = (x + 2y)/(x + y)
   = 1/3 . (1 - dx/6 + dy/6)
```


  