### PR TITLE
fix: sensitivity analysis: remove symbol % in displayed table

### DIFF
--- a/src/main/kotlin/ch/kleis/lcaplugin/ui/toolwindow/sensitivity_analysis/SensitivityTableModel.kt
+++ b/src/main/kotlin/ch/kleis/lcaplugin/ui/toolwindow/sensitivity_analysis/SensitivityTableModel.kt
@@ -67,7 +67,7 @@ class SensitivityTableModel(
                     sortedControllablePorts[columnIndex - 3],
                     analysis.getParameters().getName(rowIndex),
                 )
-                return repr(relativeSensibility, " %")
+                return repr(relativeSensibility)
             }
         }
     }

--- a/src/main/kotlin/ch/kleis/lcaplugin/ui/toolwindow/sensitivity_analysis/TransposedSensitivityTableModel.kt
+++ b/src/main/kotlin/ch/kleis/lcaplugin/ui/toolwindow/sensitivity_analysis/TransposedSensitivityTableModel.kt
@@ -70,7 +70,7 @@ class TransposedSensitivityTableModel(
                     sortedControllablePorts[rowIndex],
                     analysis.getParameters().getName(columnIndex - 3)
                 )
-                return repr(relativeSensibility, " %")
+                return repr(relativeSensibility)
             }
         }
     }


### PR DESCRIPTION
in sensitivity analysis table window, removed the possibly misleading symbol '%'