### PR TITLE
grammar: added test definitions

### DIFF
--- a/grammar/src/main/antlr/LcaLang.g4
+++ b/grammar/src/main/antlr/LcaLang.g4
@@ -1,7 +1,7 @@
 grammar LcaLang;
 
 lcaFile
-	:	pkg? pkgImport* ( processDefinition | unitDefinition | substanceDefinition | globalVariables )* EOF
+	:	pkg? pkgImport* ( processDefinition | testDefinition | unitDefinition | substanceDefinition | globalVariables )* EOF
 	;
 
 /*
@@ -26,6 +26,18 @@ globalVariables
 globalAssignment
     : dataRef EQUAL dataExpression
     ;
+
+/*
+    Test
+*/
+testDefinition
+    : TEST_KEYWORD testRef LBRACE
+        (block_given | block_assert | variables)*
+      RBRACE
+    ;
+block_given : GIVEN_KEYWORD LBRACE technoInputExchange* RBRACE ;
+block_assert : ASSERT_KEYWORD LBRACE rangeAssertion* RBRACE ;
+rangeAssertion : uid BETWEEN_KEYWORD dataExpression AND_KEYWORD dataExpression ;
 
 /*
     Substance
@@ -219,6 +231,7 @@ processRef : uid ;
 substanceRef : uid ;
 indicatorRef : uid ;
 parameterRef : uid ;
+testRef : uid ;
 
 /*
     Spec
@@ -300,6 +313,12 @@ LAND_USE_KEYWORD : 'land_use' ;
 RESOURCES_KEYWORD : 'resources' ;
 MATCH_KEYWORD : 'match' ;
 LABELS_KEYWORD : 'labels' ;
+
+TEST_KEYWORD : 'test' ;
+GIVEN_KEYWORD : 'given' ;
+ASSERT_KEYWORD : 'assert' ;
+BETWEEN_KEYWORD : 'between' ;
+AND_KEYWORD : 'and' ;
 
 EQUAL : '=' ;
 LBRACK : '[' ;

--- a/grammar/src/test/kotlin/ch/kleis/lcaac/grammar/LoaderTest.kt
+++ b/grammar/src/test/kotlin/ch/kleis/lcaac/grammar/LoaderTest.kt
@@ -14,6 +14,38 @@ import kotlin.test.assertNotNull
 
 class LoaderTest {
     @Test
+    fun load_whenFileContainsTest_thenNoError() {
+        val file = lcaFile(
+            """
+                process p {
+                    products {
+                        1 kg p
+                    }
+                    impacts {
+                        1 kg a
+                    }
+                }
+                
+                test another {
+                    given {
+                        1 kg foo
+                    }
+                    assert {
+                        bar between 40 g and 50 kg
+                    }
+                }
+            """.trimIndent()
+        )
+        val loader = Loader(BasicOperations)
+
+        // when
+        val actual = loader.load(sequenceOf(file))
+
+        // then
+        assertNotNull(actual.getTemplate("p"))
+    }
+
+    @Test
     fun load_twoProcesses_sameNameDifferentLabels() {
         // given
         val file = lcaFile(


### PR DESCRIPTION
Ne rajoute pas de features.
Ça permet juste au parser dans le core & grammar de ne pas fail quand il y a des tests dans les fichiers .lca

(notamment pour cloud assess)
